### PR TITLE
Add socket timeout for tcp connection

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -85,6 +85,7 @@ module Datadog
     # @option [Float] default sample rate if not overridden
     # @option [Boolean] single_thread flushes the metrics on the main thread instead of in a companion thread
     # @option [Boolean] delay_serialization delays stat serialization
+    # @option [Integer] timeout defines timeout for network operations
     def initialize(
       host = nil,
       port = nil,
@@ -108,7 +109,8 @@ module Datadog
       delay_serialization: false,
 
       telemetry_enable: true,
-      telemetry_flush_interval: DEFAULT_TELEMETRY_FLUSH_INTERVAL
+      telemetry_flush_interval: DEFAULT_TELEMETRY_FLUSH_INTERVAL,
+      timeout: nil
     )
       unless tags.nil? || tags.is_a?(Array) || tags.is_a?(Hash)
         raise ArgumentError, 'tags must be an array of string tags or a Hash'
@@ -144,7 +146,8 @@ module Datadog
         sender_queue_size: sender_queue_size,
 
         telemetry_flush_interval: telemetry_enable ? telemetry_flush_interval : nil,
-        serializer: serializer
+        serializer: serializer,
+        timeout: timeout
       )
     end
 

--- a/lib/datadog/statsd/connection.rb
+++ b/lib/datadog/statsd/connection.rb
@@ -3,7 +3,7 @@
 module Datadog
   class Statsd
     class Connection
-      def initialize(telemetry: nil, logger: nil)
+      def initialize(telemetry: nil, logger: nil, **_kwargs)
         @telemetry = telemetry
         @logger = logger
       end
@@ -28,6 +28,7 @@ module Datadog
           (boom.is_a?(Errno::ENOTCONN) or
            boom.is_a?(Errno::ECONNREFUSED) or
            boom.is_a?(Errno::EPIPE) or
+           boom.is_a?(Errno::ETIMEDOUT) or
            boom.is_a?(IOError) && boom.message =~ /closed stream/i)
           retries += 1
           begin

--- a/lib/datadog/statsd/forwarder.rb
+++ b/lib/datadog/statsd/forwarder.rb
@@ -23,7 +23,9 @@ module Datadog
 
         logger: nil,
 
-        serializer:
+        serializer:,
+
+        timeout: nil
       )
         @transport_type = connection_cfg.transport_type
 
@@ -36,7 +38,7 @@ module Datadog
           nil
         end
 
-        @connection = connection_cfg.make_connection(logger: logger, telemetry: telemetry)
+        @connection = connection_cfg.make_connection(logger: logger, telemetry: telemetry, timeout: timeout)
 
         # Initialize buffer
         buffer_max_payload_size ||= case @transport_type.to_sym

--- a/spec/statsd/forwarder_spec.rb
+++ b/spec/statsd/forwarder_spec.rb
@@ -107,7 +107,7 @@ describe Datadog::Statsd::Forwarder do
       it 'builds an UDP connection' do
         expect(Datadog::Statsd::UDPConnection)
           .to receive(:new)
-          .with('127.0.0.1', 1234, logger: logger, telemetry: telemetry)
+          .with('127.0.0.1', 1234, logger: logger, telemetry: telemetry, timeout: nil)
 
         subject
       end
@@ -148,7 +148,7 @@ describe Datadog::Statsd::Forwarder do
         it 'builds an UDP connection without telemetry' do
           expect(Datadog::Statsd::UDPConnection)
             .to receive(:new)
-            .with('127.0.0.1', 1234, logger: logger, telemetry: nil)
+            .with('127.0.0.1', 1234, logger: logger, telemetry: nil, timeout: nil)
 
           subject
         end
@@ -292,7 +292,7 @@ describe Datadog::Statsd::Forwarder do
       it 'builds an UDS connection' do
         expect(Datadog::Statsd::UDSConnection)
           .to receive(:new)
-          .with('/tmp/dd_socket', logger: logger, telemetry: telemetry)
+          .with('/tmp/dd_socket', logger: logger, telemetry: telemetry, timeout: nil)
 
         subject
       end
@@ -333,7 +333,7 @@ describe Datadog::Statsd::Forwarder do
         it 'builds an UDP connection without telemetry' do
           expect(Datadog::Statsd::UDSConnection)
             .to receive(:new)
-            .with('/tmp/dd_socket', logger: logger, telemetry: nil)
+            .with('/tmp/dd_socket', logger: logger, telemetry: nil, timeout: nil)
 
           subject
         end


### PR DESCRIPTION
Main changes:
- Add `connect_timeout` when establishing a connection
- Set [TCP_USER_TIMEOUT](https://tools.ietf.org/html/rfc5482) for socket to avoid long packets retransmissions

Full description - https://github.com/workato/workato/pull/40151