### PR TITLE
Remove object finalizer

### DIFF
--- a/lib/datadog/statsd.rb
+++ b/lib/datadog/statsd.rb
@@ -116,9 +116,6 @@ module Datadog
         raise ArgumentError, 'tags must be an array of string tags or a Hash'
       end
 
-      # flush metrics before client is collected by GB
-      ObjectSpace.define_finalizer(self, proc { close(flush: true) })
-
       @namespace = namespace
       @prefix = @namespace ? "#{@namespace}.".freeze : nil
       @serializer = Serialization::Serializer.new(prefix: @prefix, global_tags: tags)


### PR DESCRIPTION
relates to [MONO-469](https://workato.atlassian.net/browse/MONO-469)

In ruby 3 this generates `warning: finalizer references object to be finalized`, so probably this wasn't work properly, so I just remove this. We already added metrics flush [at exit](https://github.com/workato/workato/blob/develop/config/initializers/metrics/flush_before_exit.rb), so I think this should be enough

[MONO-469]: https://workato.atlassian.net/browse/MONO-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ